### PR TITLE
Add error priority table for `aceerror`

### DIFF
--- a/src/ace-ISA-architecture.adoc
+++ b/src/ace-ISA-architecture.adoc
@@ -367,6 +367,31 @@ software tried to use an incomplete CC in a CR as a source in an `ace.exec`, `ac
 |===
 
 
+[[norm:ace_exc_priority]]
+.ACE error priority in decreasing priority order.
+[%autowidth,float="center",align="center",cols="<,>,<",options="header",]
+|===
+|Priority     |Exc.Code        |Description
+|_Highest_    |6               |Unconfigured CR
+|           .>|5             .<|Insufficient CRF memory
+|           .>|3             .<|Invalid input/output operation with `ace.exec`, `ace.state`, +
+                                `ace.input`, `ace.output`, `ace.clone`, `ace.derive`, +
+                                `ace.harden`, or `ace.restrict` (used incomplete CC as source)
+|           .>|3             .<|Invalid input/output operation with `ace.init` (invalid metadata)
+|           .>|2, 1          .<|Access Control Failure or authentication failure with `ace.import`
+|           .>|1             .<|Authentication failure with `ace.exec`
+|           .>|3             .<|Invalid input/output operation with `ace.exec` +
+                                (form not allowed in current algorithm), +
+                                `ace.state` (state change not allowed), +
+                                or `ace.restrict` (change of usage policy is not allowed)
+|           .>|4             .<|Algorithm or algorithm variant not implemented.
+.>|_Lowest_ .>|0             .<|No error
+|===
+
+If executing an `ace.init`, `ace.import`, `ace.export`, `ace.input`, or `ace.output` triggers a
+trap, as specified in the privileged architecture, `aceerror` remains unchanged.
+
+
 [[ACE-acestart-definition]]
 ===== `acestart`
 


### PR DESCRIPTION
Executing a single `ace` instruction may result in multiple errors. This table attempts to solve priorities in these scenarios.
