### PR TITLE
Specify behavior for OOB indirect CR access

### DIFF
--- a/src/ace-ISA-architecture.adoc
+++ b/src/ace-ISA-architecture.adoc
@@ -195,6 +195,9 @@ Insufficient residual CRF capacity may prevent the execution of an instruction t
 but also `ace.clone` (cf.{nbsp}<<ACE-instruction-clone>>) or `ace.derive` (cf.{nbsp}<<ACE-instruction-derive>>).
 In this case, ACE returns _ace_err_memory_, and software must free capacity by exporting the contents of another CR (if needed) and then clearing it.
 
+Indirectly accessing a CR that is outside the defined [0 .. 31] range, results
+in a _ace_err_unconfigured_ error.
+
 [NOTE]
 ====
 CRF capacity is implementation-defined, but implementations must provide sufficient capacity to allow execution of all operations defined by the architecture.


### PR DESCRIPTION
The spec didn't specify what happened on an OOB indirect access. I added a paragraph to the Cryptographic Register definition stating the expected behavior.