### PR TITLE
Set metadata errors with a higher exception than memory errors 

### DIFF
--- a/src/ace-ISA-architecture.adoc
+++ b/src/ace-ISA-architecture.adoc
@@ -618,7 +618,7 @@ software tried to use an incomplete CC in a CR as a source in an `ace.exec`, `ac
 .ACE error priority in decreasing priority order.
 [%autowidth,float="center",align="center",cols="<,>,<",options="header",]
 |===
-.>|Priority   .>|Exception +
+.>|Priority   .>|Error +
 Code        .>|Description
 .>|_Highest_  |6               |Unconfigured CR
 |           .>|3             .>|Invalid input/output operation with `ace.init` (invalid metadata)


### PR DESCRIPTION
Metadata needs to be valid prior to any allocation taking place.
Otherwise, allocations would be taking place with a possibly invalid
metadata.