### PR TITLE
Add virt semantics, add move operation to `ace.exec`, and expand load semantics

### DIFF
--- a/src/ace-ISA-algorithms.adoc
+++ b/src/ace-ISA-algorithms.adoc
@@ -82,6 +82,7 @@ is not yet complete or contains ambiguities.
 | 7    | 3    | `Ascon-Hash256`            | `Zlascon`
 | 7    | 4    | `Ascon-XOF128`             | `Zlascon`
 | 7    | 5    | `Ascon-CXOF128`            | `Zlascon`
+| 8    | 0    | Move vector register to CR at offset `acestart`, and increment `acestart` by `vl`. | `Zlaes128p`
 |===
 
 //

--- a/src/ace-ISA-priv.adoc
+++ b/src/ace-ISA-priv.adoc
@@ -144,6 +144,18 @@ Writes to ACES do not modify any other ACE state. Setting ACES to Off, Initial, 
 
 In implementations with a writable `misa.L`, the `mstatus.ACES` field may be present even when `misa.L` is clear, analogously to `mstatus.FS` and `mstatus.VS`.
 
+When `TSR` is set to 1, all ACE memory instructions cause an
+illegal-instruction exception in S-mode.
+
+[NOTE]
+====
+ACE memory instructions are allowed to trap so that implementations have more
+flexibility when loading/storing large ACE contexts. Simpler implementations
+may defer the load/store process to software using scalar or vector
+loads/stores followed by an `ace.exec` move, whereas more performant
+implementations may have dedicated hardware to speedup the instructions.
+====
+
 // ////////////////////////////////////////////////////////////////////
 
 [[ACE-ACES-field-H]]
@@ -162,6 +174,9 @@ When V=1:
 * When `vsstatus.ACES` is Dirty, `vsstatus.SD` is 1; else, `vsstatus.SD` is set per existing specifications.
 
 In implementations with a writable `misa.L`, `vsstatus.ACES` may be present even when `misa.L` is clear.
+
+When `VTSR` is set to 1, all ACE memory instructions cause a
+virtual-instruction exception in VS-mode.
 
 // ////////////////////////////////////////////////////////////////////
 

--- a/src/ace-ISA-unpriv.adoc
+++ b/src/ace-ISA-unpriv.adoc
@@ -1015,6 +1015,15 @@ _Description_::
 Ths instruction requires that the CR is ready to import information and that the first 8 bytes of the MDH have already been loaded.
 Therefore, if the _ConfigStatus_ field is equal to _CfgStComplete_, an invalid instruction exception is raised.
 
+`ace.load` can load data that may be larger than the effective XLEN. `acestart`
+keeps track of the number of loaded bytes. If `ace.load` is interrupted,
+`acestart` contains the offset to the next byte to load upon resumption.
+
+NOTE: Modifying the CR being used by the interrupted `ace.load` always forces
+the load to restart. Software that aims to optimize this case will have to
+inspect `ConfigStatus` in the metadata of each CR and detect if the load hasn't
+completed to impede the restart.
+
 The semantics of `ace.load` in case the key is in a system-defined format
 are entirely implementation dependent and do not assume that the CR has been readied to import information and
 that some metadata has already been loaded in it.
@@ -1070,6 +1079,16 @@ The operation starts with the 8th byte of the MDH.
 The instruction itself determines the length of the output from the MDH.
 
 The first 8 bytes of the MDH must be read from the CR using `ace.getmdl` and saved to memory by the software.
+
+`ace.store` can store data that may be larger than the effective XLEN.
+`acestart` keeps track of the number of stored bytes. If `ace.store` is
+interrupted, `acestart` contains the offset to the next byte to store upon
+resumption.
+
+NOTE: Modifying the CR being used by the interrupted `ace.store` always forces
+the store to restart. Software that aims to optimize this case will have to
+inspect `ConfigStatus` in the the metadata of each CR and detect if the store
+hasn't completed to impede the restart.
 
 If the _ConfigStatus_ field is equal to _CfgStComplete_, then an invalid instruction exception is raised.
 


### PR DESCRIPTION
- **Define (V)TSR semantics for ACE memory instructions**
- **Code and describe move operation**
- **Explicitly state that loads/stores update `acestart`**

I don't think we need to explicitly state it is expected that the SCC/prov data
is buffered before being available in the CR. This case is only relevant during
interrupts. I belive the non-normative note should be sufficient for a reader
to understand that touching the interrupted CR implictly impedes a resumption.

PTAL.
